### PR TITLE
[ISSUE #23] fix: bug with the setting of BrowserView to BrowserWindow

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -33,11 +33,11 @@ const activateTab = tabId => {
   const activeTab = tabManager.getTab(tabId);
   if (activeTab) {
     const {width, height} = mainWindow.getContentBounds();
-    tabContainer.setBounds({x: 0, y: 0, width, height: TABS_CONTAINER_HEIGHT});
     mainWindow.setBrowserView(tabContainer);
-    tabManager.setActiveTab(tabId);
-    activeTab.setBounds({x: 0, y: TABS_CONTAINER_HEIGHT, width, height: height - TABS_CONTAINER_HEIGHT});
     mainWindow.addBrowserView(activeTab);
+    tabManager.setActiveTab(tabId);
+    tabContainer.setBounds({x: 0, y: 0, width, height: TABS_CONTAINER_HEIGHT});
+    activeTab.setBounds({x: 0, y: TABS_CONTAINER_HEIGHT, width, height: height - TABS_CONTAINER_HEIGHT});
     activeTab.webContents.focus();
   }
 };


### PR DESCRIPTION
Rearranging the setter and adder of `BrowserView` to `BrowserWindow`, and putting the `.setBounds()` calls after them.
This fix will prevent the current bug in https://github.com/electron/electron/issues/20064.

I'm requesting the pull to **master** branch, because I couldn't find any other candidate branch for it, but let me know if I should proceed differently (like a develop / fix / RC branch)

Also, it would be a plus for me if someone could test this branch in their Windows/Linux environments to confirm it's still working, considering that currently I don't have access to any of those environments (appartment in the beach, and only with macOS laptop, what can I say).