### PR TITLE
Features/#3 Disabling notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,9 @@
     }
   },
   "jest": {
-    "setupFilesAfterEnv": ["jest-extended"]
+    "setupFilesAfterEnv": [
+      "jest-extended"
+    ]
   },
   "devDependencies": {
     "@testing-library/dom": "^7.20.0",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -25,6 +25,7 @@ const APP_EVENTS = {
   settingsSave: 'settingsSave',
   setTabFavicon: 'setTabFavicon',
   setTabTitle: 'setTabTitle',
+  canNotify: 'canNotify',
   tabsReady: 'tabsReady',
   tabReorder: 'tabReorder',
   zoomIn: 'zoomIn',

--- a/src/settings/__tests__/index.test.js
+++ b/src/settings/__tests__/index.test.js
@@ -97,37 +97,6 @@ describe('Settings module test suite', () => {
         '  "otherSetting": "1337"\n}');
     });
   });
-  describe('updateTabUrls', () => {
-    test('No tab URLs provided and existing tabs, should save empty array', () => {
-      // Given
-      fs.existsSync.mockImplementation(() => true);
-      fs.readFileSync.mockImplementation(
-        () => '{"enabledDictionaries":[], "tabs": [{"id": "1", "url": "http://to-be-removed"}]}');
-      // When
-      settings.updateTabUrls([]);
-      // Then
-      expect(fs.writeFileSync).toHaveBeenCalledWith(path.join('$HOME', '.electronim', 'settings.json'),
-        '{\n  "tabs": [],\n  "enabledDictionaries": []\n}');
-    });
-    test('New tab URLs provided and existing tabs, should save new tabs', () => {
-      // Given
-      fs.existsSync.mockImplementation(() => true);
-      fs.readFileSync.mockImplementation(
-        () => '{"enabledDictionaries":[], "tabs": [{"id": "1", "url": "http://to-be-kept", "otherSetting": 1337}]}');
-      // When
-      settings.updateTabUrls([
-        {id: '1', url: 'http://to-be-kept', sandboxed: true},
-        {id: '1337', url: 'http://new-tab'}
-      ]);
-      // Then
-      expect(fs.readFileSync).toHaveBeenCalledTimes(3);
-      expect(fs.writeFileSync).toHaveBeenCalledWith(path.join('$HOME', '.electronim', 'settings.json'),
-        '{\n  "tabs": [\n' +
-        '    {\n      "id": "1",\n      "url": "http://to-be-kept",\n      "sandboxed": true\n    },\n' +
-        '    {\n      "id": "1337",\n      "url": "http://new-tab"\n    }\n  ],\n' +
-        '  "enabledDictionaries": []\n}');
-    });
-  });
   describe('openSettingsDialog', () => {
     test('', () => {
       // Given

--- a/src/settings/__tests__/preload.test.js
+++ b/src/settings/__tests__/preload.test.js
@@ -20,7 +20,7 @@ describe('Settings Module preload test suite', () => {
     mockSpellCheck = {
       AVAILABLE_DICTIONARIES: 'someAvailableDictionaries', getEnabledDictionaries: jest.fn(() => '1337')
     };
-    mockSettings = {loadSettings: jest.fn(() => ({tabs: ['1337']}))};
+    mockSettings = {loadSettings: jest.fn(() => ({tabs: ['1337'], disableNotificationsGlobally: false}))};
     jest.resetModules();
     jest.mock('../../main/preload', () => {
       global.mainPreloadLoaded = true;
@@ -39,5 +39,6 @@ describe('Settings Module preload test suite', () => {
     expect(window.dictionaries.enabled).toBe('1337');
     expect(mockSettings.loadSettings).toHaveBeenCalledTimes(1);
     expect(window.tabs).toEqual(['1337']);
+    expect(window.disableNotificationsGlobally).toBe(false);
   });
 });

--- a/src/settings/browser-settings.css
+++ b/src/settings/browser-settings.css
@@ -78,6 +78,12 @@ body {
     max-height: 100px;
 }
 
+.settings__global-notifications {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
 .settings__dictionaries .control input[type="checkbox"] {
     margin-right: var(--default-spacing);
 }

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -47,14 +47,6 @@ const writeSettings = settings => {
 
 const updateSettings = settings => writeSettings({...loadSettings(), ...settings});
 
-const updateTabUrls = updatedTabs => {
-  const {activeTab} = loadSettings();
-  updateSettings({tabs: [...updatedTabs]});
-  if (updatedTabs.length > 0 && !updatedTabs.map(({id}) => id).includes(activeTab)) {
-    updateSettings({activeTab: updatedTabs[0].id});
-  }
-};
-
 const openSettingsDialog = mainWindow => {
   const settingsView = new BrowserView({webPreferences});
   mainWindow.setBrowserView(settingsView);
@@ -64,4 +56,4 @@ const openSettingsDialog = mainWindow => {
   settingsView.webContents.loadURL(`file://${__dirname}/index.html`);
 };
 
-module.exports = {loadSettings, updateSettings, updateTabUrls, openSettingsDialog};
+module.exports = {loadSettings, updateSettings, openSettingsDialog};

--- a/src/settings/preload.js
+++ b/src/settings/preload.js
@@ -32,3 +32,5 @@ window.dictionaries = {
 };
 
 window.tabs = [...settings.tabs];
+
+window.disableNotificationsGlobally = settings.disableNotificationsGlobally;

--- a/src/tab-manager/__tests__/browser-notification-shim.test.js
+++ b/src/tab-manager/__tests__/browser-notification-shim.test.js
@@ -1,11 +1,16 @@
 describe('Browser Notification Shim test suite', () => {
   let NativeNotification;
   let electron;
+  let mockedElectron;
   beforeEach(() => {
     jest.resetModules();
-    jest.mock('electron', () => ({
-      ipcRenderer: {send: jest.fn()}
-    }));
+    mockedElectron = {
+      ipcRenderer: {
+        send: jest.fn(),
+        sendSync: jest.fn(() => true)
+      }
+    };
+    jest.mock('electron', () => mockedElectron);
     electron = require('electron');
     NativeNotification = jest.fn();
     NativeNotification.maxActions = jest.fn();
@@ -18,58 +23,72 @@ describe('Browser Notification Shim test suite', () => {
     };
     window.Notification = NativeNotification;
   });
-  test('Native Notification should be shimmed and used as delegate', () => {
-    // Given
-    require('../browser-notification-shim');
-    // When
-    const notification = new Notification();
-    Notification.maxActions();
-    Notification.permission();
-    Notification.requestPermission();
-    // Then
-    expect(window.Notification).not.toBe(NativeNotification);
-    expect(NativeNotification).toHaveBeenCalledTimes(1);
-    expect(NativeNotification.maxActions).toHaveBeenCalledTimes(1);
-    expect(NativeNotification.permission).toHaveBeenCalledTimes(1);
-    expect(NativeNotification.requestPermission).toHaveBeenCalledTimes(1);
-    expect(notification.actions).toBe('Actions');
-    expect(notification.badge).toBe('Badge');
-    expect(notification.body).toBe('Body');
-    expect(notification.data).toBe('Data');
-    expect(notification.dir).toBe('Dir');
-    expect(notification.lang).toBe('Lang');
-    expect(notification.tag).toBe('Tag');
-    expect(notification.icon).toBe('Icon');
-    expect(notification.image).toBe('Image');
-    expect(notification.renotify).toBe('Renotify');
-    expect(notification.requireInteraction).toBe('RequireInteraction');
-    expect(notification.silent).toBe('Silent');
-    expect(notification.timestamp).toBe('Timestamp');
-    expect(notification.title).toBe('Title');
-    expect(notification.vibrate).toBe('Vibrate');
-    notification.close();
-    expect(NativeNotification.prototype.close).toHaveBeenCalledTimes(1);
+  describe('Notifications are enabled for the current tab', () => {
+    test('Native Notification should be shimmed and used as delegate', () => {
+      // Given
+      require('../browser-notification-shim');
+      // When
+      const notification = new Notification();
+      Notification.maxActions();
+      Notification.permission();
+      Notification.requestPermission();
+      // Then
+      expect(window.Notification).not.toBe(NativeNotification);
+      expect(NativeNotification).toHaveBeenCalledTimes(1);
+      expect(NativeNotification.maxActions).toHaveBeenCalledTimes(1);
+      expect(NativeNotification.permission).toHaveBeenCalledTimes(1);
+      expect(NativeNotification.requestPermission).toHaveBeenCalledTimes(1);
+      expect(notification.actions).toBe('Actions');
+      expect(notification.badge).toBe('Badge');
+      expect(notification.body).toBe('Body');
+      expect(notification.data).toBe('Data');
+      expect(notification.dir).toBe('Dir');
+      expect(notification.lang).toBe('Lang');
+      expect(notification.tag).toBe('Tag');
+      expect(notification.icon).toBe('Icon');
+      expect(notification.image).toBe('Image');
+      expect(notification.renotify).toBe('Renotify');
+      expect(notification.requireInteraction).toBe('RequireInteraction');
+      expect(notification.silent).toBe('Silent');
+      expect(notification.timestamp).toBe('Timestamp');
+      expect(notification.title).toBe('Title');
+      expect(notification.vibrate).toBe('Vibrate');
+      notification.close();
+      expect(NativeNotification.prototype.close).toHaveBeenCalledTimes(1);
+    });
+    test('Notification should ALWAYS be clickable', () => {
+      // Given
+      require('../browser-notification-shim');
+      const notification = new Notification();
+      // When
+      notification.onclick(null);
+      // Then
+      expect(electron.ipcRenderer.send).toHaveBeenCalledTimes(1);
+      expect(electron.ipcRenderer.send).toHaveBeenCalledWith('notificationClick', expect.any(Object));
+    });
+    test('Notification onclick setter, should add custom behavior', () => {
+      // Given
+      require('../browser-notification-shim');
+      const notification = new Notification();
+      const webAppOnclick = jest.fn();
+      notification.onclick = webAppOnclick;
+      // When
+      notification.onclick(null);
+      // Then
+      expect(webAppOnclick).toHaveBeenCalledTimes(1);
+      expect(electron.ipcRenderer.send).toHaveBeenCalledTimes(1);
+    });
   });
-  test('Notification should ALWAYS be clickable', () => {
-    // Given
-    require('../browser-notification-shim');
-    const notification = new Notification();
-    // When
-    notification.onclick(null);
-    // Then
-    expect(electron.ipcRenderer.send).toHaveBeenCalledTimes(1);
-    expect(electron.ipcRenderer.send).toHaveBeenCalledWith('notificationClick', expect.any(Object));
-  });
-  test('Notification onclick setter, should add custom behavior', () => {
-    // Given
-    require('../browser-notification-shim');
-    const notification = new Notification();
-    const webAppOnclick = jest.fn();
-    notification.onclick = webAppOnclick;
-    // When
-    notification.onclick(null);
-    // Then
-    expect(webAppOnclick).toHaveBeenCalledTimes(1);
-    expect(electron.ipcRenderer.send).toHaveBeenCalledTimes(1);
+  describe('Notifications for this particular tab are disabled', () => {
+    test('notification should not delegate, and should return empty object', () => {
+      // Given
+      mockedElectron.ipcRenderer.sendSync = jest.fn(() => false);
+      require('../browser-notification-shim');
+      // When
+      const notification = new Notification();
+      // Then
+      expect(notification).toEqual({});
+      expect(NativeNotification).not.toBeCalled();
+    });
   });
 });

--- a/src/tab-manager/browser-notification-shim.js
+++ b/src/tab-manager/browser-notification-shim.js
@@ -24,91 +24,96 @@ const NativeNotification = Notification;
 
 const bubbleNotification = () => ipcRenderer.send(APP_EVENTS.notificationClick, {tabId: window.tabId});
 
+const canNotify = () => ipcRenderer.sendSync(APP_EVENTS.canNotify, window.tabId);
+
 const setDelegateMinimumBehavior = delegate => {
   delegate.onclick = bubbleNotification;
 };
 
 // noinspection JSValidateTypes
 Notification = function() {
-  const delegate = new NativeNotification(...arguments);
-  setDelegateMinimumBehavior(delegate);
-  return {
-    get actions() {
-      return delegate.actions;
-    },
-    get badge() {
-      return delegate.badge;
-    },
-    get body() {
-      return delegate.body;
-    },
-    get data() {
-      return delegate.data;
-    },
-    get dir() {
-      return delegate.dir;
-    },
-    get lang() {
-      return delegate.lang;
-    },
-    get tag() {
-      return delegate.tag;
-    },
-    get icon() {
-      return delegate.icon;
-    },
-    get image() {
-      return delegate.image;
-    },
-    get renotify() {
-      return delegate.renotify;
-    },
-    get requireInteraction() {
-      return delegate.requireInteraction;
-    },
-    get silent() {
-      return delegate.silent;
-    },
-    get timestamp() {
-      return delegate.timestamp;
-    },
-    get title() {
-      return delegate.title;
-    },
-    get vibrate() {
-      return delegate.vibrate;
-    },
-    get onclick() {
-      return delegate.onclick;
-    },
-    set onclick(func) {
-      delegate.onclick = event => {
-        bubbleNotification();
-        func(event);
-      };
-    },
-    get onclose() {
-      return delegate.onclose;
-    },
-    set onclose(func) {
-      delegate.onclose = func;
-    },
-    get onerror() {
-      return delegate.onerror;
-    },
-    set onerror(func) {
-      delegate.onerror = func;
-    },
-    get onshow() {
-      return delegate.onshow;
-    },
-    set onshow(func) {
-      delegate.onshow = func;
-    },
-    get close() {
-      return delegate.close;
-    }
-  };
+  if (canNotify()) {
+    const delegate = new NativeNotification(...arguments);
+    setDelegateMinimumBehavior(delegate);
+    return {
+      get actions() {
+        return delegate.actions;
+      },
+      get badge() {
+        return delegate.badge;
+      },
+      get body() {
+        return delegate.body;
+      },
+      get data() {
+        return delegate.data;
+      },
+      get dir() {
+        return delegate.dir;
+      },
+      get lang() {
+        return delegate.lang;
+      },
+      get tag() {
+        return delegate.tag;
+      },
+      get icon() {
+        return delegate.icon;
+      },
+      get image() {
+        return delegate.image;
+      },
+      get renotify() {
+        return delegate.renotify;
+      },
+      get requireInteraction() {
+        return delegate.requireInteraction;
+      },
+      get silent() {
+        return delegate.silent;
+      },
+      get timestamp() {
+        return delegate.timestamp;
+      },
+      get title() {
+        return delegate.title;
+      },
+      get vibrate() {
+        return delegate.vibrate;
+      },
+      get onclick() {
+        return delegate.onclick;
+      },
+      set onclick(func) {
+        delegate.onclick = event => {
+          bubbleNotification();
+          func(event);
+        };
+      },
+      get onclose() {
+        return delegate.onclose;
+      },
+      set onclose(func) {
+        delegate.onclose = func;
+      },
+      get onerror() {
+        return delegate.onerror;
+      },
+      set onerror(func) {
+        delegate.onerror = func;
+      },
+      get onshow() {
+        return delegate.onshow;
+      },
+      set onshow(func) {
+        delegate.onshow = func;
+      },
+      get close() {
+        return delegate.close;
+      }
+    };
+  }
+  return {};
 };
 
 Notification.maxActions = NativeNotification.maxActions;

--- a/src/tab-manager/index.js
+++ b/src/tab-manager/index.js
@@ -119,6 +119,12 @@ const removeAll = () => {
 
 const reload = () => Object.values(tabs).forEach(browserView => browserView.webContents.reload());
 
+const canNotify = tabId => {
+  const {tabs: tabsSettings, disableNotificationsGlobally} = settings.loadSettings();
+  const currentTab = tabsSettings.find(tab => tab.id === tabId);
+  return !(currentTab.disableNotifications || disableNotificationsGlobally);
+};
+
 module.exports = {
-  addTabs, getTab, getActiveTab, setActiveTab, reload, removeAll
+  addTabs, getTab, getActiveTab, setActiveTab, canNotify, reload, removeAll
 };


### PR DESCRIPTION
First of all, I'm somewhat stupid, and started committing with the number of the issue 2. This PR is for the feature #3 

Next, I included modifications in the settings window to:

- include icons for enabling/disabling notifications in every tab (respecting the awful design provided by @manusa )
- include a different setting to control globally the notifications of the application

Finally, I also included the changes to retrieve those settings, and:

- For each tab **DO NOT CREATE** a Notification object if notifications are disabled (either globally or for that particular tab)
- Also, sounds were still playing when a message arrived to the service included in the tab, so I muted the entire tab.