### PR TITLE
fix: :bug: fix black squares in gmail

### DIFF
--- a/src/user-agent/index.js
+++ b/src/user-agent/index.js
@@ -85,6 +85,7 @@ const addUserAgentInterceptor = session => {
       if (
         details.url.match(/https?:\/\/[^/]+google\.com.*/) // NOSONAR
         && !details.url.match(/https?:\/\/meet.google\.com.*/)
+        && !details.url.match(/https?:\/\/mail.google\.com.*/)
       ) {
         details.requestHeaders['User-Agent'] = firefoxUserAgent(details.requestHeaders['User-Agent'])(BROWSER_VERSIONS.firefoxESR);
       }


### PR DESCRIPTION
Fix #106 

Icons were displayed as black squares. the addUserAgentInterceptor was to large and I added a check for gmail

Before
![image](https://user-images.githubusercontent.com/342110/190903879-770df136-019f-4243-9b8b-bf1bf1725b11.png)

After
![image](https://user-images.githubusercontent.com/342110/190903903-ab2063ce-fc4e-4bc9-a496-4e7968c96501.png)

I confirm the sign in is still possible with no "browser security check"

