### PR TITLE
🤖 fix sRPM doesn't include every /usr/bin file

### DIFF
--- a/build-config/electronim.spec
+++ b/build-config/electronim.spec
@@ -61,6 +61,6 @@ install -Dp -m0755 %{SOURCE1} %{buildroot}%{_datadir}/applications
 %{_optpkgdir}/*
 %dir %{_datadir}/applications
 %{_datadir}/applications/%{name}.desktop
-%{_bindir}/*
+%{_bindir}/electronim
 
 


### PR DESCRIPTION
Should fix:

```
Error: Transaction test error:
  file /usr/lib/.build-id/21/79f0c994368adf0e9287396aa6382939ef5866 from install of electronim-0.0.87-0.fc37.x86_64 conflicts with file from package python3-3.11.0-1.fc37.x86_64
```

Relates to:
- https://github.com/manusa/electronim/issues/241
