### PR TITLE
🤖(rpm-spec) remove python3 binary

### DIFF
--- a/build-config/electronim.spec
+++ b/build-config/electronim.spec
@@ -39,6 +39,9 @@ GITHUB_REF=refs/tags/v%{version} node ./utils/version-from-tag.js
 node ./utils/prepare-electron-builder.js
 npm run build:linux
 
+# Remove bin files that might collision with local system binaries
+rm -f dist/linux-unpacked/resources/app.asar.unpacked/node_modules/nodehun/build/node_gyp_bins/python3
+
 %install
 # install everything to /opt/%%{pkg_name}
 install -dp %{buildroot}%{_optpkgdir}


### PR DESCRIPTION
Should fix:
```
Error: Transaction test error:
  file /usr/lib/.build-id/21/79f0c994368adf0e9287396aa6382939ef5866 from install of electronim-0.0.87-0.fc37.x86_64 conflicts with file from package python3-3.11.0-1.fc37.x86_64
```
