### PR TITLE
#350 - don't return promise in dom-ready handler

### DIFF
--- a/src/tab-manager/index.js
+++ b/src/tab-manager/index.js
@@ -105,9 +105,11 @@ const addTabs = ipcSender => tabsMetadata => {
 
     tab.webContents.on('context-menu', handleContextMenu(tab));
 
-    const registerIdInTab = () => tab.webContents.executeJavaScript(`window.tabId = '${id}';`);
+    const registerIdInTab = () => {
+      tab.webContents.executeJavaScript(`window.tabId = '${id}';`);
+    };
     tab.webContents.on('dom-ready', registerIdInTab);
-    registerIdInTab().then();
+    registerIdInTab();
 
     tabs[id.toString()] = tab;
   });


### PR DESCRIPTION
`then` call is not needed to fire the promise, you just should not return anything, which will make the callback return value a void

Fixes #350 