### PR TITLE
🐛 Fix WhatsApp Favicon Not Displaying Due to net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "dictionary-tr": "^1.3.3",
         "dictionary-uk": "^2.1.1",
         "electron": "30.0.9",
+        "helmet": "^7.1.0",
         "htm": "3.1.1",
         "markdown-it": "14.1.0",
         "nodehun": "3.0.2",
@@ -5439,6 +5440,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -13682,6 +13692,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "optional": true
+    },
+    "helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
     },
     "hosted-git-info": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -122,14 +122,14 @@
       "icon": "icon_1024x1024.png",
       "target": [
         {
-          "target":"dmg",
+          "target": "dmg",
           "arch": [
             "x64",
             "arm64"
           ]
         },
         {
-          "target":"tar.gz",
+          "target": "tar.gz",
           "arch": [
             "x64",
             "arm64"
@@ -206,8 +206,8 @@
     "dictionary-ca": "2.6.0",
     "dictionary-ca-valencia": "2.6.0",
     "dictionary-de": "2.0.4",
-    "dictionary-en-gb": "2.4.0",
     "dictionary-en": "3.2.0",
+    "dictionary-en-gb": "2.4.0",
     "dictionary-es": "3.2.0",
     "dictionary-eu": "3.2.0",
     "dictionary-fr": "2.8.0",
@@ -223,6 +223,7 @@
     "dictionary-tr": "^1.3.3",
     "dictionary-uk": "^2.1.1",
     "electron": "30.0.9",
+    "helmet": "^7.1.0",
     "htm": "3.1.1",
     "markdown-it": "14.1.0",
     "nodehun": "3.0.2",

--- a/src/chrome-tabs/chrome-tabs.browser.css
+++ b/src/chrome-tabs/chrome-tabs.browser.css
@@ -52,6 +52,8 @@ body {
   /* https://github.com/vaadin/web-components/issues/4183 */
   /* Prevents https://bugs.chromium.org/p/chromium/issues/detail?id=1399431 */
   -webkit-mask-image: none;
+  display: flex;
+  align-items: center;
 }
 
 .tab-container .chrome-tabs .chrome-tab .chrome-tab-content::after {

--- a/src/chrome-tabs/chrome-tabs.browser.css
+++ b/src/chrome-tabs/chrome-tabs.browser.css
@@ -56,6 +56,11 @@ body {
   align-items: center;
 }
 
+.tab-container .chrome-tabs .chrome-tab .chrome-tab-content img{
+  width: 16px;
+  height: 16px;
+}
+
 .tab-container .chrome-tabs .chrome-tab .chrome-tab-content::after {
   content: '';
   position: absolute;

--- a/src/chrome-tabs/chrome-tabs.browser.mjs
+++ b/src/chrome-tabs/chrome-tabs.browser.mjs
@@ -61,12 +61,14 @@ const isInVisibleArea = event =>
   event.clientX <= window.innerWidth && event.clientY <= window.innerHeight;
 
 const Favicon = ({favicon = ''}) => {
-  const faviconProps = {hidden: true};
+  let img = html``;
   if (favicon) {
-    faviconProps.style = `background-image: url("${favicon}");`;
-    delete faviconProps.hidden;
+    img = html`<img crossorigin="anonymous" src="${favicon}" alt="favicon" width="16px" height="16px"/>`;
   }
-  return html`<div class="chrome-tab-favicon" ...${faviconProps}></div>`;
+  return html`
+      <div class="chrome-tab-favicon">
+          ${img}
+      </div>`;
 };
 
 const NotificationIcon = ({disableNotifications = false}) => disableNotifications && html`

--- a/src/chrome-tabs/chrome-tabs.browser.mjs
+++ b/src/chrome-tabs/chrome-tabs.browser.mjs
@@ -63,7 +63,7 @@ const isInVisibleArea = event =>
 const Favicon = ({favicon = ''}) => {
   let img = html``;
   if (favicon) {
-    img = html`<img crossorigin="anonymous" src="${favicon}" alt="favicon" width="16px" height="16px"/>`;
+    img = html`<img crossorigin="anonymous" src="${favicon}" alt="" role="presentation"/>`;
   }
   return html`
       <div class="chrome-tab-favicon">


### PR DESCRIPTION
This pull request fixes the issue where the WhatsApp favicon was not displaying due to a net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin error. Previously, the favicon was applied as a background image within a div, which caused cross-origin restrictions to block it.

The solution involves:

- Replacing the background image in the div with an <img> tag that includes the crossorigin="anonymous" attribute to handle cross-origin restrictions.
- Updating the CSS to explicitly set the size of the favicon by applying width: 16px and height: 16px to the image inside the tab container.