### PR TITLE
🐛 Fix WhatsApp Favicon Not Displaying Due to net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin ErrorFix/whatsapp icon

### DIFF
--- a/src/chrome-tabs/__tests__/chrome-tabs.browser.test.mjs
+++ b/src/chrome-tabs/__tests__/chrome-tabs.browser.test.mjs
@@ -60,8 +60,8 @@ describe('ChromeTabs in Browser test suite', () => {
       expect($addedTabs[1].querySelector('.chrome-tab-title').innerHTML)
         .toBe('313373');
       expect($addedTabs[1].hasAttribute('active')).toBe(false);
-      expect($addedTabs[2].querySelector('.chrome-tab-favicon').style.backgroundImage)
-        .toBe('url(https://13373.png)');
+      expect($addedTabs[2].querySelector('.chrome-tab-favicon-icon').getAttribute('src'))
+        .toBe('https://13373.png');
       expect(mockIpcRenderer.send).toHaveBeenCalledWith('activateTab', {id: 1337, restoreWindow: false});
     });
     test('activateTabInContainer, should change active tab', async () => {
@@ -95,11 +95,11 @@ describe('ChromeTabs in Browser test suite', () => {
       mockIpcRenderer.events.setTabFavicon({}, {id: 313373, favicon: 'https://f/replaced.png'});
       // Then
       await waitFor(() => expect(
-        $chromeTabs.querySelector('.chrome-tab[data-tab-id="313373"] .chrome-tab-favicon').style.backgroundImage)
-        .toBe('url(https://f/replaced.png)'));
+        $chromeTabs.querySelector('.chrome-tab[data-tab-id="313373"] .chrome-tab-favicon-icon').getAttribute('src'))
+        .toBe('https://f/replaced.png'));
       expect(
-        $chromeTabs.querySelector('.chrome-tab[data-tab-id="13373"] .chrome-tab-favicon').style.backgroundImage)
-        .toBe('url(https://13373.png)');
+        $chromeTabs.querySelector('.chrome-tab[data-tab-id="13373"] .chrome-tab-favicon-icon').getAttribute('src'))
+        .toBe('https://13373.png');
     });
     test('setTabTitle, should change title of specified tab', async () => {
       // Given

--- a/src/chrome-tabs/chrome-tabs.browser.css
+++ b/src/chrome-tabs/chrome-tabs.browser.css
@@ -56,9 +56,9 @@ body {
   align-items: center;
 }
 
-.tab-container .chrome-tabs .chrome-tab .chrome-tab-content img{
-  width: 16px;
-  height: 16px;
+.tab-container .chrome-tabs .chrome-tab .chrome-tab-content .chrome-tab-favicon-icon {
+  width: var(--chrome-tab-favicon-size);
+  height: var(--chrome-tab-favicon-size);
 }
 
 .tab-container .chrome-tabs .chrome-tab .chrome-tab-content::after {

--- a/src/chrome-tabs/chrome-tabs.browser.css
+++ b/src/chrome-tabs/chrome-tabs.browser.css
@@ -52,6 +52,13 @@ body {
   /* https://github.com/vaadin/web-components/issues/4183 */
   /* Prevents https://bugs.chromium.org/p/chromium/issues/detail?id=1399431 */
   -webkit-mask-image: none;
+  display: flex;
+  align-items: center;
+}
+
+.tab-container .chrome-tabs .chrome-tab .chrome-tab-content img{
+  width: 16px;
+  height: 16px;
 }
 
 .tab-container .chrome-tabs .chrome-tab .chrome-tab-content::after {

--- a/src/chrome-tabs/chrome-tabs.browser.mjs
+++ b/src/chrome-tabs/chrome-tabs.browser.mjs
@@ -63,7 +63,9 @@ const isInVisibleArea = event =>
 const Favicon = ({favicon = ''}) => {
   let img = html``;
   if (favicon) {
-    img = html`<img crossorigin="anonymous" src="${favicon}" alt="" role="presentation"/>`;
+    img = html`
+      <img class="chrome-tab-favicon-icon" crossorigin="anonymous" src="${favicon}" alt="" role="presentation"/>
+    `;
   }
   return html`
       <div class="chrome-tab-favicon">

--- a/src/chrome-tabs/chrome-tabs.browser.mjs
+++ b/src/chrome-tabs/chrome-tabs.browser.mjs
@@ -61,12 +61,14 @@ const isInVisibleArea = event =>
   event.clientX <= window.innerWidth && event.clientY <= window.innerHeight;
 
 const Favicon = ({favicon = ''}) => {
-  const faviconProps = {hidden: true};
+  let img = html``;
   if (favicon) {
-    faviconProps.style = `background-image: url("${favicon}");`;
-    delete faviconProps.hidden;
+    img = html`<img crossorigin="anonymous" src="${favicon}" alt="" role="presentation"/>`;
   }
-  return html`<div class="chrome-tab-favicon" ...${faviconProps}></div>`;
+  return html`
+      <div class="chrome-tab-favicon">
+          ${img}
+      </div>`;
 };
 
 const NotificationIcon = ({disableNotifications = false}) => disableNotifications && html`
@@ -192,8 +194,8 @@ const TabContainer = () => {
     sendTabsReady();
   }, []);
   return html`
-    <${ChromeTabs} state=${state} dispatch=${dispatch}/>
-    <${Menu} state=${state}/>
+      <${ChromeTabs} state=${state} dispatch=${dispatch}/>
+          <${Menu} state=${state}/>
   `;
 };
 

--- a/src/styles/base/variables.css
+++ b/src/styles/base/variables.css
@@ -16,6 +16,7 @@
 :root {
   --default-spacing: 6px;
   --tab-container-height: 46px;
+  --chrome-tab-favicon-size: 16px;
   /*--material3-field-height: 56px;*/
   /* Material 3 default height is too big for us, reduce it to something more appealing */
   --material3-field-height: 40px;


### PR DESCRIPTION
_Originally authored by @lukasborges_ in #430

> This pull request fixes the issue where the WhatsApp favicon was not displaying due to a net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin error. Previously, the favicon was applied as a background image within a div, which caused cross-origin restrictions to block it.
> 
> The solution involves:
> 
> - Replacing the background image in the div with an <img> tag that includes the crossorigin="anonymous" attribute to handle cross-origin restrictions.
> - Updating the CSS to explicitly set the size of the favicon by applying width: 16px and height: 16px to the image inside the tab container.