### PR TITLE
🐛 revert: force native spell check until Electron issue is fixed

### DIFF
--- a/src/settings/settings.spell-check.browser.mjs
+++ b/src/settings/settings.spell-check.browser.mjs
@@ -44,10 +44,6 @@ export const SpellCheckPane = ({dispatch, state}) => {
           checked=${useNative}
           onClick=${toggleProperty({dispatch, property: 'useNativeSpellChecker'})}
       />
-      <div data-testid='settings-todo-native-spell-check' style=${{'font-size': '1.1rem', 'padding-left': '0.5rem'}}>
-        <p>NOTE: Currently, the Native Spell Checker is <strong>always</strong> used due to a bug in Electron:</p>
-        <p><a href='https://github.com/electron/electron/issues/44336'>electron/issues/44336</a></p>
-      </div>
       <${Card.Divider} />
       <div class='settings__dictionaries'>${
   Object.entries(dictionaries(state))

--- a/src/spell-check/index.js
+++ b/src/spell-check/index.js
@@ -87,13 +87,7 @@ const getAvailableNativeDictionaries = () =>
 const handleGetMisspelled = async (_event, words) =>
   fakeRendererWorker.webContents.executeJavaScript(`getMisspelled(${JSON.stringify(words)})`);
 
-const getUseNativeSpellChecker = () => {
-  // eslint-disable-next-line no-warning-comments
-  // TODO: always use native spellcheck until there's a fix for
-  // https://github.com/electron/electron/issues/44336
-  return true;
-  // return loadSettings().useNativeSpellChecker;
-};
+const getUseNativeSpellChecker = () => loadSettings().useNativeSpellChecker;
 
 const getEnabledDictionaries = () => loadSettings().enabledDictionaries;
 


### PR DESCRIPTION
Reverts #464 

Upstream issue (https://github.com/electron/electron/issues/44336) fixed in:
- https://github.com/electron/electron/pull/45001
- https://github.com/electron/electron/pull/45021
